### PR TITLE
DM-44230: Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-2.0.1'></a>
+## 2.0.1 (2024-05-07)
+
+### Bug fixes
+
+- Remove the unwanted query parameter from the `GET /fastapi-bootcamp/en-greeting` endpoint.
+
 <a id='changelog-2.0.0'></a>
 ## 2.0.0 (2024-05-07)
 

--- a/changelog.d/20240507_203911_jsick_DM_44230.md
+++ b/changelog.d/20240507_203911_jsick_DM_44230.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Remove the unwanted query parameter from the `GET /fastapi-bootcamp/en-greeting` endpoint.

--- a/changelog.d/20240507_203911_jsick_DM_44230.md
+++ b/changelog.d/20240507_203911_jsick_DM_44230.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Remove the unwanted query parameter from the `GET /fastapi-bootcamp/en-greeting` endpoint.

--- a/src/fastapibootcamp/handlers/external.py
+++ b/src/fastapibootcamp/handlers/external.py
@@ -380,7 +380,7 @@ class ErrorRequestModel(BaseModel):
     "/error-demo", summary="Raise an internal service exception."
 )
 async def post_error_demo(data: ErrorRequestModel) -> JSONResponse:
-    """Use the custom_error field to compare the different between raising
+    """Use the custom_error field to compare the difference between raising
     a custom SlackException and a generic exception.
     """
     if data.custom_error:

--- a/src/fastapibootcamp/handlers/external.py
+++ b/src/fastapibootcamp/handlers/external.py
@@ -154,11 +154,9 @@ class GreetingResponseModel(BaseModel):
     summary="Get a greeting in English.",
     response_model=GreetingResponseModel,
 )
-async def get_english_greeting(
-    language: Annotated[Language, Query()] = Language.en,
-) -> GreetingResponseModel:
+async def get_english_greeting() -> GreetingResponseModel:
     return GreetingResponseModel(
-        greeting="Hello, SQuaRE Services Bootcamp!", language=language
+        greeting="Hello, SQuaRE Services Bootcamp!", language=Language.en
     )
 
 


### PR DESCRIPTION
- Remove unwanted query param from `/en-greeting`. This was left from separating lesson 2 into 2 and 2a.